### PR TITLE
Update rustbridge discord link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ sass:
 links:
   contact:
     Twitter: "https://twitter.com/rustbridge"
-    Discord: "https://discord.gg/DpBApCd"
+    Discord: "https://discord.gg/jEKp4bXC"
     GitHub: "https://github.com/rustbridge/"
   resources:
     "Rust": "https://www.rust-lang.org/"


### PR DESCRIPTION
Hi, it was mentioned in the rust discord that the invite link on the rustbridge website was out of date.  This PR updates the link with a new working invite to the \#rustbridge channel.  

If the user isnt already a member of the rust discord, they will have to go through the \#welcome channel and acquire the talk role.  Its not exactly an obvious path to the \#rustbridge channel.  It may make more sense to link to the \#welcome channel instead.  